### PR TITLE
gitignore .DS_Store 파일 추적 제외

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ hs_err_pid*
 .idea/
 .idea/libraries/
 target/
+
+### MacOS ###
+*.DS_Store


### PR DESCRIPTION
자동으로 생기는 파일을 관리대상에서 제외시켰습니다.